### PR TITLE
[RFC][ELF] Add --compress-ections

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -212,6 +212,8 @@ struct Config {
   bool checkSections;
   bool checkDynamicRelocs;
   llvm::DebugCompressionType compressDebugSections;
+  llvm::SmallVector<std::pair<llvm::GlobPattern, llvm::DebugCompressionType>, 0>
+      compressSections;
   bool cref;
   llvm::SmallVector<std::pair<llvm::GlobPattern, uint64_t>, 0>
       deadRelocInNonAlloc;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1431,6 +1431,23 @@ static void readConfigs(opt::InputArgList &args) {
     }
   }
 
+  for (opt::Arg *arg : args.filtered(OPT_compress_sections)) {
+    SmallVector<StringRef, 0> fields;
+    StringRef(arg->getValue()).split(fields, '=');
+    if (fields.size() != 2 || fields[1].empty()) {
+      error(arg->getSpelling() +
+            ": parse error, not 'section-glob=[zlib|zstd]'");
+      continue;
+    }
+    auto type = getCompressionType(fields[1], arg->getSpelling());
+    if (Expected<GlobPattern> pat = GlobPattern::create(fields[0])) {
+      config->compressSections.emplace_back(std::move(*pat), type);
+    } else {
+      error(arg->getSpelling() + ": " + toString(pat.takeError()));
+      continue;
+    }
+  }
+
   for (opt::Arg *arg : args.filtered(OPT_z)) {
     std::pair<StringRef, StringRef> option =
         StringRef(arg->getValue()).split('=');

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -64,6 +64,9 @@ defm compress_debug_sections:
   Eq<"compress-debug-sections", "Compress DWARF debug sections">,
   MetaVarName<"[none,zlib,zstd]">;
 
+defm compress_sections: EEq<"compress-sections", "Compress output sections matching <section-glob>">,
+  MetaVarName<"<section-glob>=[zlib|zstd]">;
+
 defm defsym: Eq<"defsym", "Define a symbol alias">, MetaVarName<"<symbol>=<value>">;
 
 defm optimize_bb_jumps: BB<"optimize-bb-jumps",

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -23,6 +23,7 @@ struct PhdrEntry;
 
 struct CompressedData {
   std::unique_ptr<SmallVector<uint8_t, 0>[]> shards;
+  uint32_t type = 0;
   uint32_t numShards = 0;
   uint32_t checksum = 0;
   uint64_t uncompressedSize;
@@ -116,11 +117,12 @@ public:
   void sortInitFini();
   void sortCtorsDtors();
 
+  // Used for implementation of --compress-debug-sections and
+  // --compress-sections.
+  CompressedData compressed;
+
 private:
   SmallVector<InputSection *, 0> storage;
-
-  // Used for implementation of --compress-debug-sections option.
-  CompressedData compressed;
 
   std::array<uint8_t, 4> getFiller();
 };

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -148,6 +148,8 @@ to set the compression level to 6.
 The compression level is 5.
 .El
 .Pp
+.It Fl -compress-sections Ns = Ns Ar section-glob=[zlib|zstd]
+Compress output sections matching the glob with zlib or zstd.
 .It Fl -cref
 Output cross reference table. If
 .Fl Map

--- a/lld/test/ELF/compress-sections-err.s
+++ b/lld/test/ELF/compress-sections-err.s
@@ -5,8 +5,11 @@
 # RUN: ld.lld %t.o --compress-debug-sections=zlib --compress-debug-sections=none -o /dev/null 2>&1 | count 0
 # RUN: not ld.lld %t.o --compress-debug-sections=zlib -o /dev/null 2>&1 | \
 # RUN:   FileCheck %s --implicit-check-not=error:
+# RUN: not ld.lld %t.o --compress-sections=foo=zlib -o /dev/null 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=CHECK2 --implicit-check-not=error:
 
 # CHECK: error: --compress-debug-sections: LLVM was not built with LLVM_ENABLE_ZLIB or did not find zlib at build time
+# CHECK2: error: --compress-sections: LLVM was not built with LLVM_ENABLE_ZLIB or did not find zlib at build time
 
 .globl _start
 _start:

--- a/lld/test/ELF/compress-sections.s
+++ b/lld/test/ELF/compress-sections.s
@@ -1,0 +1,96 @@
+# REQUIRES: x86, zlib, zstd
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t.o
+# RUN: ld.lld -pie %t.o -o %t --compress-sections '*0=zlib' --compress-sections '*0=none'
+# RUN: llvm-readelf -Srs %t | FileCheck %s --check-prefix=CHECK1
+
+# CHECK1:      foo0       PROGBITS [[#%x,FOO0:]]    [[#%x,]] [[#%x,]] 00 A   0 0  1
+# CHECK1-NEXT: foo1       PROGBITS [[#%x,FOO1:]]    [[#%x,]] [[#%x,]] 00 A   0 0  1
+# CHECK1-NEXT: .text      PROGBITS [[#%x,TEXT:]]    [[#%x,]] [[#%x,]] 00 AX  0 0  4
+# CHECK1:      write0     PROGBITS [[#%x,WRITE0:]]  [[#%x,]] [[#%x,]] 00 WA  0 0  1
+# CHECK1-NEXT: nonalloc0  PROGBITS 0000000000000000 [[#%x,]] [[#%x,]] 00     0 0  1
+# CHECK1-NEXT: nonalloc1  PROGBITS 0000000000000000 [[#%x,]] [[#%x,]] 00     0 0  1
+# CHECK1-NEXT: .debug_str PROGBITS 0000000000000000 [[#%x,]] [[#%x,]] 01 MS  0 0  1
+
+# CHECK1:          Offset          {{.*}} Type              Symbol's Value  Symbol's Name + Addend
+# CHECK1-NEXT: {{0*}}[[#WRITE0]]   {{.*}} R_X86_64_RELATIVE                 [[#TEXT]]
+# CHECK1-NEXT: {{0*}}[[#WRITE0+8]] {{.*}} R_X86_64_RELATIVE                 [[#TEXT]]
+
+# CHECK1: [[#FOO0]]      0 NOTYPE  LOCAL  DEFAULT   [[#]] foo0_sym
+# CHECK1: [[#FOO1]]      0 NOTYPE  LOCAL  DEFAULT   [[#]] foo1_sym
+# CHECK1: [[#FOO0]]      0 NOTYPE  GLOBAL PROTECTED [[#]] __start_foo0
+# CHECK1: [[#FOO1]]      0 NOTYPE  GLOBAL PROTECTED [[#]] __stop_foo0
+
+# RUN: ld.lld -pie %t.o -o %t --compress-sections '*0=zlib' --compress-sections .debug_str=zstd
+# RUN: llvm-readelf -Srs -x foo0 -x write0 -x nonalloc0 -x .debug_str %t | FileCheck %s --check-prefix=CHECK2
+
+# CHECK2:      foo0       PROGBITS [[#%x,FOO0:]]    [[#%x,]] [[#%x,]] 00 AC  0 0  1
+# CHECK2-NEXT: foo1       PROGBITS [[#%x,FOO1:]]    [[#%x,]] [[#%x,]] 00 A   0 0  1
+# CHECK2-NEXT: .text      PROGBITS [[#%x,TEXT:]]    [[#%x,]] [[#%x,]] 00 AX  0 0  4
+# CHECK2:      write0     PROGBITS [[#%x,WRITE0:]]  [[#%x,]] [[#%x,]] 00 WAC 0 0  1
+# CHECK2-NEXT: nonalloc0  PROGBITS 0000000000000000 [[#%x,]] [[#%x,]] 00 C   0 0  1
+# CHECK2-NEXT: nonalloc1  PROGBITS 0000000000000000 [[#%x,]] [[#%x,]] 00     0 0  1
+# CHECK2-NEXT: .debug_str PROGBITS 0000000000000000 [[#%x,]] [[#%x,]] 01 MSC 0 0  1
+
+# CHECK2:          Offset          {{.*}} Type              Symbol's Value  Symbol's Name + Addend
+# CHECK2-NEXT: {{0*}}[[#WRITE0]]   {{.*}} R_X86_64_RELATIVE                 [[#TEXT]]
+# CHECK2-NEXT: {{0*}}[[#WRITE0+8]] {{.*}} R_X86_64_RELATIVE                 [[#TEXT]]
+
+# CHECK2:      Hex dump of section 'foo0':
+## zlib with ch_size=0x10
+# CHECK2-NEXT: 01000000 00000000 10000000 00000000
+# CHECK2-NEXT: 01000000 00000000 {{.*}}
+# CHECK2:      Hex dump of section 'write0':
+## zlib with ch_size=0x10
+# CHECK2-NEXT: 01000000 00000000 10000000 00000000
+# CHECK2-NEXT: 01000000 00000000 {{.*}}
+# CHECK2:      Hex dump of section 'nonalloc0':
+## zlib with ch_size=0x10
+# CHECK2-NEXT: 01000000 00000000 10000000 00000000
+# CHECK2-NEXT: 01000000 00000000 {{.*}}
+# CHECK2:      Hex dump of section '.debug_str':
+## zstd with ch_size=0x38
+# CHECK2-NEXT: 02000000 00000000 38000000 00000000
+# CHECK2-NEXT: 01000000 00000000 {{.*}}
+
+# RUN: not ld.lld --compress-sections=foo %t.o -o /dev/null 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=ERR1 --implicit-check-not=error:
+# ERR1:      error: --compress-sections: parse error, not 'section-glob=[zlib|zstd]'
+
+# RUN: not ld.lld --compress-sections 'a[=zlib' %t.o -o /dev/null 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=ERR2 --implicit-check-not=error:
+# ERR2:      error: --compress-sections: invalid glob pattern: a[
+
+# RUN: not ld.lld %t.o -o /dev/null --compress-sections='.debug*=zlib-gabi' --compress-sections='.debug*=' 2>&1 | \
+# RUN:   FileCheck -check-prefix=ERR3 %s
+# ERR3:      unknown --compress-sections value: zlib-gabi
+# ERR3-NEXT: --compress-sections: parse error, not 'section-glob=[zlib|zstd]'
+
+.globl _start
+_start:
+  leaq __start_foo0(%rip), %rax
+  leaq __stop_foo0(%rip), %rax
+  ret
+
+.section foo0,"a"
+foo0_sym:
+.quad .text-.
+.quad .text-.
+.section foo1,"a"
+foo1_sym:
+.quad .text-.
+.quad .text-.
+.section write0,"aw"
+.quad .text
+.quad .text
+.section nonalloc0,""
+.quad .text
+.quad .text
+.section nonalloc1,""
+.quad 42
+
+.section .debug_str,"MS",@progbits,1
+.Linfo_string0:
+  .asciz "AAAAAAAAAAAAAAAAAAAAAAAAAAA"
+.Linfo_string1:
+  .asciz "BBBBBBBBBBBBBBBBBBBBBBBBBBB"

--- a/lld/test/ELF/linkerscript/compress-sections.s
+++ b/lld/test/ELF/linkerscript/compress-sections.s
@@ -1,0 +1,53 @@
+# REQUIRES: x86, zlib
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+# RUN: not ld.lld -T a.lds a.o --compress-sections 'foo=zlib' 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
+
+# ERR: error: uncompressed size of SHF_COMPRESSED section 'foo' is dependent on linker script commands
+
+# RUN: ld.lld -T b.lds a.o --compress-sections 'foo=zlib' -o a
+# RUN: llvm-readelf -Ss a | FileCheck %s
+
+# CHECK: .text    PROGBITS [[#%x,]]        [[#%x,]] [[#%x,]] 00 AX 0 0  4
+# CHECK: foo      PROGBITS [[#%x,FOO:]]    [[#%x,]] [[#%x,]] 00 AC 0 0  1
+# CHECK: bar      PROGBITS [[#%x,BAR:]]    [[#%x,]] [[#%x,]] 00 A  0 0  1
+
+# CHECK: [[#FOO]]      0 NOTYPE  LOCAL  DEFAULT   [[#]] foo0_sym
+# CHECK: [[#FOO+8]]    0 NOTYPE  LOCAL  DEFAULT   [[#]] foo1_sym
+# CHECK: [[#FOO]]      0 NOTYPE  GLOBAL PROTECTED [[#]] __start_foo
+# CHECK: [[#BAR]]      0 NOTYPE  GLOBAL PROTECTED [[#]] __stop_foo
+
+#--- a.s
+.globl _start
+_start:
+  leaq __start_foo(%rip), %rax
+  leaq __stop_foo(%rip), %rax
+  ret
+
+.section foo0,"a"
+foo0_sym:
+.quad 42
+.section foo1,"a"
+foo1_sym:
+.quad 42
+.section bar,"a"
+.quad 42
+
+#--- a.lds
+SECTIONS {
+  foo : { *(foo*) . += a; }
+  .text : { *(.text) }
+  a = b+1;
+  b = c+1;
+  c = SIZEOF(.text);
+}
+
+#--- b.lds
+SECTIONS {
+  .text : { *(.text) }
+  c = SIZEOF(.text);
+  b = c+1;
+  a = b+1;
+  foo : { *(foo*) QUAD(SIZEOF(foo)) . += a; }
+}


### PR DESCRIPTION
This option is like a generalized --compress-debug-sections that applies
to arbitrary sections, including SHF_ALLOC ones ([1])

GNU ld feature request: https://sourceware.org/bugzilla/show_bug.cgi?id=27452

[1]: https://groups.google.com/g/generic-abi/c/HUVhliUrTG0 ("Allow SHF_ALLOC | SHF_COMPRESSED sections")